### PR TITLE
FIX issue #198: wrong linker used

### DIFF
--- a/cargo-apk/linker.rs
+++ b/cargo-apk/linker.rs
@@ -37,6 +37,7 @@ fn main() {
         .arg("-o").arg(args.cargo_apk_linker_output)
         .arg("-shared")
         .arg("-Wl,-E")
+        .arg("-gcc-toolchain").arg(args.cargo_apk_gcc_toolchain)
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status().unwrap().code().unwrap() != 0
@@ -55,6 +56,7 @@ struct Args {
 
     cargo_apk_gcc: String,
     cargo_apk_gcc_sysroot: String,
+    cargo_apk_gcc_toolchain: String,
     cargo_apk_native_app_glue: String,
     cargo_apk_glue_obj: String,
     cargo_apk_glue_lib: String,
@@ -72,6 +74,7 @@ fn parse_arguments() -> (Args, Vec<String>) {
 
     let mut cargo_apk_gcc: Option<String> = None;
     let mut cargo_apk_gcc_sysroot: Option<String> = None;
+    let mut cargo_apk_gcc_toolchain: Option<String> = None;
     let mut cargo_apk_native_app_glue: Option<String> = None;
     let mut cargo_apk_glue_obj: Option<String> = None;
     let mut cargo_apk_glue_lib: Option<String> = None;
@@ -93,6 +96,8 @@ fn parse_arguments() -> (Args, Vec<String>) {
                         .expect("Missing cargo_apk_gcc option in linker"),
                     cargo_apk_gcc_sysroot: cargo_apk_gcc_sysroot
                         .expect("Missing cargo_apk_gcc_sysroot option in linker"),
+                    cargo_apk_gcc_toolchain: cargo_apk_gcc_toolchain
+                        .expect("Missing cargo_apk_gcc_toolchain option in linker"),
                     cargo_apk_native_app_glue: cargo_apk_native_app_glue
                         .expect("Missing cargo_apk_native_app_glue option in linker"),
                     cargo_apk_glue_obj: cargo_apk_glue_obj
@@ -118,6 +123,9 @@ fn parse_arguments() -> (Args, Vec<String>) {
             "--cargo-apk-gcc-sysroot" => {
                 cargo_apk_gcc_sysroot = Some(args.next().unwrap());
             },
+            "--cargo-apk-gcc-toolchain" => {
+                cargo_apk_gcc_toolchain = Some(args.next().unwrap());
+            }
             "--cargo-apk-native-app-glue" => {
                 cargo_apk_native_app_glue = Some(args.next().unwrap());
             },

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -29,6 +29,11 @@ fn main() {
         Err(err) => cargo::exit_with_error(err.into(), &mut *cargo_config.shell()),
     };
 
+    let args = match args.subcommand() {
+        ("apk", Some(subcommand_matches)) => subcommand_matches,
+        _ => &args
+    };
+
     let (command, subcommand_args)  = match args.subcommand() {
         (command, Some(subcommand_args)) => (command, subcommand_args),
         _ => {
@@ -61,7 +66,7 @@ fn main() {
         "logcat" => execute_logcat(&subcommand_args, &cargo_config),
         _ => {
             cargo::exit_with_error(
-                format_err!("Expected `build`, `install`, `run`, or `logcat`").into(),
+                format_err!("Expected `build`, `install`, `run`, or `logcat`. Got {}", command).into(),
                 &mut *cargo_config.shell())
         }
     };
@@ -79,11 +84,25 @@ fn cli() -> App<'static, 'static> {
         AppSettings::VersionlessSubcommands,
         AppSettings::AllowExternalSubcommands,
     ]).subcommands(vec![
+        cli_apk(),
         cli_build(),
         cli_install(),
         cli_run(),
         cli_logcat(),
     ]).arg(opt("verbose", "Verbose output"))
+}
+
+fn cli_apk() -> App<'static, 'static> {
+    SubCommand::with_name("apk").settings(&[
+        AppSettings::UnifiedHelpMessage,
+        AppSettings::DeriveDisplayOrder,
+        AppSettings::DontCollapseArgsInUsage,
+    ]).about("dummy subcommand to allow for calling cargo apk instead of cargo-apk")
+      .subcommands(vec![
+          cli_build(),
+          cli_install(),
+          cli_run(),
+          cli_logcat()])
 }
 
 fn cli_build() -> App<'static, 'static> {

--- a/cargo-apk/src/ops/build.rs
+++ b/cargo-apk/src/ops/build.rs
@@ -49,7 +49,7 @@ pub fn build(workspace: &Workspace, config: &AndroidConfig, options: &ArgMatches
         let build_target_dir = android_artifacts_dir.join(build_target);
 
         // Finding the tools in the NDK.
-        let (gcc_path, gxx_path, ar_path) = {
+        let (gcc_path, gxx_path, ar_path, gcc_toolchain) = {
             let host_os = if cfg!(target_os = "windows") { "windows" }
                        else if cfg!(target_os = "linux") { "linux" }
                        else if cfg!(target_os = "macos") { "darwin" }
@@ -76,7 +76,8 @@ pub fn build(workspace: &Workspace, config: &AndroidConfig, options: &ArgMatches
             let base = config.ndk_path.join(format!("toolchains/{}-4.9/prebuilt/{}-x86_64", target_arch, host_os));
             (base.join(format!("bin/{}-gcc", tool_prefix)),
              base.join(format!("bin/{}-g++", tool_prefix)),
-             base.join(format!("bin/{}-ar", tool_prefix)))
+             base.join(format!("bin/{}-ar", tool_prefix)),
+             base)
         };
 
         let gcc_sysroot_linker = {
@@ -206,6 +207,8 @@ pub fn build(workspace: &Workspace, config: &AndroidConfig, options: &ArgMatches
                 "-C".to_owned(), format!("link-arg={}", gcc_path.as_os_str().to_str().unwrap().to_owned()),
                 "-C".to_owned(),"link-arg=--cargo-apk-gcc-sysroot".to_owned(),
                 "-C".to_owned(), format!("link-arg={}", gcc_sysroot_linker.as_os_str().to_str().unwrap().to_owned()),
+                "-C".to_owned(),"link-arg=--cargo-apk-gcc-toolchain".to_owned(),
+                "-C".to_owned(), format!("link-arg={}", gcc_toolchain.as_os_str().to_str().unwrap().to_owned()),
                 "-C".to_owned(), "link-arg=--cargo-apk-native-app-glue".to_owned(),
                 "-C".to_owned(), format!("link-arg={}", build_target_dir.join("android_native_app_glue.o").into_os_string().into_string().unwrap()),
                 "-C".to_owned(), "link-arg=--cargo-apk-glue-obj".to_owned(),


### PR DESCRIPTION
according to https://stackoverflow.com/questions/52646860 the -gcc-toolchain
flag is now required starting with ndk-r18