### PR TITLE
Circle CI update with readme fix.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ jobs:
       - run:
           name: Publish final image
           command: |
-            docker login -u $DOCKERHUB_LOGIN -p $DOCKERHUB_PASSWORD
-            docker push IMAGE_NAME
+            echo "$DOCKERHUB_PASSWORD" | docker login -u $DOCKERHUB_LOGIN --password-stdin
+            docker push $IMAGE_NAME
 workflows:
   version: 2
   all:

--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@
 ## With Docker
 
 The easiest way to compile for Android is to use [Docker](https://www.docker.com/) and the
-[tomaka/cargo-apk](https://hub.docker.com/r/tomaka/cargo-apk/) image.
+[philipalldredge/cargo-apk](https://hub.docker.com/r/philipalldredge/cargo-apk/) image.
 
 In order to build an APK, simply do this:
 
 ```
-docker run --rm -v <path-to-local-directory-with-Cargo.toml>:/root/src tomaka/cargo-apk cargo apk build
+docker run --rm -v <path-to-local-directory-with-Cargo.toml>:/root/src philipalldredge/cargo-apk cargo apk build
 ```
 
 For example if you're on Linux and you want to compile the project in the current working
 directory.
 
 ```
-docker run --rm -v "$(pwd):/root/src" -w /root/src tomaka/cargo-apk cargo apk build
+docker run --rm -v "$(pwd):/root/src" -w /root/src philipalldredge/cargo-apk cargo apk build
 ```
 
 Do not mount a volume on `/root` or you will erase the local installation of Cargo.


### PR DESCRIPTION
@mb64 
#226 did not publish the docker image as hoped. The error messages and warnings produced are below. This pull requests reverts the README to reference my docker image until the automated build is fixed. It should also fix the security warning. However, the warning appears to be just a warning and the real error is the username or password is incorrect. I do not expect this to fix the publishing issue.

I recommend pushing so that the README will point to the newer docker image until we can workout the authentication issues with publishing. I don't have access to the Circle CI control panel so someone else will need to fix that part or grant me access.

> #!/bin/sh -eo pipefail
> docker login -u $DOCKERHUB_LOGIN -p $DOCKERHUB_PASSWORD
> docker push IMAGE_NAME
> WARNING! Using --password via the CLI is insecure. Use --password-stdin.
> Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password
> Exited with code 1