### PR TITLE
Fix broken build when using rust 1.37.0 support 

### DIFF
--- a/cargo-apk/injected-glue/lib.rs
+++ b/cargo-apk/injected-glue/lib.rs
@@ -644,18 +644,17 @@ pub fn load_asset(filename: &str) -> Result<Vec<u8>, AssetError> {
 
 // Exported function which is called be Android's NativeActivity
 #[no_mangle]
-#[inline(never)]
 pub unsafe extern "C" fn ANativeActivity_onCreate(
     activity: *mut c_void,
     saved_state: *mut c_void,
     saved_state_size: usize,
 ) {
-    ANativeActivity_onCreate2(activity, saved_state, saved_state_size);
+    native_app_glue_onCreate(activity, saved_state, saved_state_size);
 }
 
 extern "C" {
     #[allow(non_snake_case)]
-    fn ANativeActivity_onCreate2(
+    fn native_app_glue_onCreate(
         activity: *mut c_void,
         saved_state: *mut c_void,
         saved_state_size: usize,

--- a/cargo-apk/injected-glue/lib.rs
+++ b/cargo-apk/injected-glue/lib.rs
@@ -641,3 +641,23 @@ pub fn load_asset(filename: &str) -> Result<Vec<u8>, AssetError> {
     };
     Ok(vec)
 }
+
+// Exported function which is called be Android's NativeActivity
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn ANativeActivity_onCreate(
+    activity: *mut c_void,
+    saved_state: *mut c_void,
+    saved_state_size: usize,
+) {
+    ANativeActivity_onCreate2(activity, saved_state, saved_state_size);
+}
+
+extern "C" {
+    #[allow(non_snake_case)]
+    fn ANativeActivity_onCreate2(
+        activity: *mut c_void,
+        saved_state: *mut c_void,
+        saved_state_size: usize,
+    );
+}

--- a/cargo-apk/native_app_glue/android_native_app_glue.c
+++ b/cargo-apk/native_app_glue/android_native_app_glue.c
@@ -420,8 +420,10 @@ static void onInputQueueDestroyed(ANativeActivity* activity, AInputQueue* queue)
     android_app_set_input((struct android_app*)activity->instance, NULL);
 }
 
+// Renamed to ANativeActivity_onCreate2 to allow injected-glue to define ANativeActivity_onCreate which will
+// will be exported and will call this function.
 JNIEXPORT
-void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState,
+void ANativeActivity_onCreate2(ANativeActivity* activity, void* savedState,
                               size_t savedStateSize) {
     LOGV("Creating: %p\n", activity);
     activity->callbacks->onDestroy = onDestroy;

--- a/cargo-apk/native_app_glue/android_native_app_glue.c
+++ b/cargo-apk/native_app_glue/android_native_app_glue.c
@@ -420,10 +420,9 @@ static void onInputQueueDestroyed(ANativeActivity* activity, AInputQueue* queue)
     android_app_set_input((struct android_app*)activity->instance, NULL);
 }
 
-// Renamed to ANativeActivity_onCreate2 to allow injected-glue to define ANativeActivity_onCreate which will
-// will be exported and will call this function.
-JNIEXPORT
-void ANativeActivity_onCreate2(ANativeActivity* activity, void* savedState,
+// Called by ANativeActivity_onCreate which will be exported and will call this function.
+// Needed because this symbol will not be globally exported.
+void native_app_glue_onCreate(ANativeActivity* activity, void* savedState,
                               size_t savedStateSize) {
     LOGV("Creating: %p\n", activity);
     activity->callbacks->onDestroy = onDestroy;

--- a/cargo-apk/src/main.rs
+++ b/cargo-apk/src/main.rs
@@ -325,7 +325,7 @@ pub fn execute_install(options: &ArgMatches, cargo_config: &CargoConfig) -> carg
         &workspace,
         &options.value_of("package").map(|s| s.to_owned()),
     )?;
-    android_config.release = options.is_present("release");
+    android_config.release = !options.is_present("debug");
 
     ops::install(&workspace, &android_config, &options)?;
     Ok(())

--- a/cargo-apk/src/ops/build/compile.rs
+++ b/cargo-apk/src/ops/build/compile.rs
@@ -215,14 +215,14 @@ pub extern "C" fn android_main(app: *mut ()) {{
             fs::create_dir_all(&build_path).unwrap();
 
             //
-            // Change crate-type from bin to dylib
+            // Change crate-type from bin to cdylib
             // Replace output directory with the directory we created
             //
             let mut iter = new_args.iter_mut().rev().peekable();
             while let Some(arg) = iter.next() {
                 if let Some(prev_arg) = iter.peek() {
                     if *prev_arg == "--crate-type" && arg == "bin" {
-                        *arg = "dylib".into();
+                        *arg = "cdylib".into();
                     } else if *prev_arg == "--out-dir" {
                         *arg = build_path.clone().into();
                     }


### PR DESCRIPTION
Build using cargo-apk and rust 1.37.0 results in a binary which does not export `ANativeActivity_onCreate`. Seems related to https://github.com/rust-lang/rust/issues/62088.

This fixes that issue and also switches to using cdylib. The cdylib switch is not necessary for the fix but it is more correct and reduces file sizes.

This also resolves #236 by supporting the debug flag in the install command and automatically builds with release. This is in line with `cargo install` behavior and it is in line with the behavior described when using `--help`.

Should resolve #236, #235 and parts of #234.