### PR TITLE
Fixed the `mem::uninitialized` warnings

### DIFF
--- a/glue/src/lib.rs
+++ b/glue/src/lib.rs
@@ -60,11 +60,7 @@ pub enum MotionAction {
     Cancel,
 }
 
-<<<<<<< HEAD
 #[derive(Clone, Copy, Debug)]
-=======
-#[derive(Debug)]
->>>>>>> a213eecde1b7b93fe0e6480b06c6494e1324896d
 pub enum AssetError {
     AssetMissing,
     EmptyBuffer,

--- a/glue/src/lib.rs
+++ b/glue/src/lib.rs
@@ -81,7 +81,7 @@ pub fn add_sender(sender: Sender<Event>) {
 
 /// Adds a SyncEventHandler which will receive sync events from the polling loop.
 #[inline]
-pub fn add_sync_event_handler(handler: Box<SyncEventHandler>) {
+pub fn add_sync_event_handler(handler: Box<dyn SyncEventHandler>) {
     unsafe {
         let handler = Box::into_raw(Box::new(handler)) as *mut _;
         cargo_apk_injected_glue_add_sync_event_handler(handler);
@@ -90,7 +90,7 @@ pub fn add_sync_event_handler(handler: Box<SyncEventHandler>) {
 
 /// Removes a SyncEventHandler.
 #[inline]
-pub fn remove_sync_event_handler(handler: *const SyncEventHandler) {
+pub fn remove_sync_event_handler(handler: *const dyn SyncEventHandler) {
     unsafe {
         let handler = Box::into_raw(Box::new(handler)) as *mut _;
         cargo_apk_injected_glue_remove_sync_event_handler(handler);
@@ -143,7 +143,7 @@ pub fn load_asset(filename: &str) -> Result<Vec<u8>, AssetError> {
     }
 }
 
-// Wakes the event poll asynchronously and sends a Event::Wake event to the senders. 
+// Wakes the event poll asynchronously and sends a Event::Wake event to the senders.
 // This method can be called on any thread. This method returns immediately.
 #[inline]
 pub fn wake_event_loop() {

--- a/glue/src/lib.rs
+++ b/glue/src/lib.rs
@@ -60,10 +60,20 @@ pub enum MotionAction {
     Cancel,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum AssetError {
     AssetMissing,
     EmptyBuffer,
 }
+
+impl std::fmt::Display for AssetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self);
+        Ok(())
+    }
+}
+
+impl std::error::Error for AssetError {}
 
 // Trait used to dispatch sync events from the polling loop thread.
 pub trait SyncEventHandler {

--- a/glue/src/lib.rs
+++ b/glue/src/lib.rs
@@ -2,13 +2,13 @@
 
 extern {
     fn cargo_apk_injected_glue_get_native_window() -> *const c_void;
-    fn cargo_apk_injected_glue_add_sender(sender: *mut ());
-    fn cargo_apk_injected_glue_add_sender_missing(sender: *mut ());
-    fn cargo_apk_injected_glue_add_sync_event_handler(sender: *mut ());
-    fn cargo_apk_injected_glue_remove_sync_event_handler(sender: *mut ());
+    fn cargo_apk_injected_glue_add_sender(sender: *mut c_void);
+    fn cargo_apk_injected_glue_add_sender_missing(sender: *mut c_void);
+    fn cargo_apk_injected_glue_add_sync_event_handler(sender: *mut c_void);
+    fn cargo_apk_injected_glue_remove_sync_event_handler(sender: *mut c_void);
     fn cargo_apk_injected_glue_set_multitouch(multitouch: bool);
-    fn cargo_apk_injected_glue_write_log(ptr: *const (), len: usize);
-    fn cargo_apk_injected_glue_load_asset(ptr: *const (), len: usize) -> *mut c_void;
+    fn cargo_apk_injected_glue_write_log(ptr: *const c_void, len: usize);
+    fn cargo_apk_injected_glue_load_asset(ptr: *const c_void, len: usize) -> *mut c_void;
     fn cargo_apk_injected_glue_wake_event_loop();
 }
 
@@ -68,8 +68,7 @@ pub enum AssetError {
 
 impl std::fmt::Display for AssetError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self);
-        Ok(())
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
Used [__`MaybeUninit`__](https://doc.rust-lang.org/beta/std/mem/union.MaybeUninit.html) to solve the warnings and also added a few `dyn`s where they were missing. 