### PR TITLE
Automatically publish new versions to crates.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,8 @@ jobs:
     steps:
       - run: apt-get -qq update && apt-get install -y git
       - checkout
-      - run: cargo publish --token $CRATESIO_TOKEN
+      - run: cd ./cargo-apk && cargo publish --token $CRATESIO_TOKEN
+      - run: cd ./glue && cargo publish --token $CRATESIO_TOKEN
 workflows:
   version: 2
   all:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,28 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASSWORD" | docker login -u $DOCKERHUB_LOGIN --password-stdin
             docker push $IMAGE_NAME
+  publish-crates-io:
+    working_directory: ~/android-rs-glue
+    environment:
+      IMAGE_NAME: tomaka/cargo-apk
+    docker:
+      - image: docker:stable
+    steps:
+      - run: apt-get -qq update && apt-get install -y git
+      - checkout
+      - run: cargo publish --token $CRATESIO_TOKEN
 workflows:
   version: 2
   all:
     jobs:
       - build-and-test
       - publish-docker-image:
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
+      - publish-crates-io:
           requires:
             - build-and-test
           filters:


### PR DESCRIPTION
Should address #221. I'm not 100% sure if this will work since I don't have a whole lot of experience with CircleCI, but the validator accepted it at the very least.