### PR TITLE
Attempt to fix crates.io auto-publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ jobs:
     docker:
       - image: docker:stable
     steps:
-      - run: apt-get -qq update && apt-get install -y git
       - checkout
       - run: cd ./cargo-apk && cargo publish --token $CRATESIO_TOKEN
       - run: cd ./glue && cargo publish --token $CRATESIO_TOKEN


### PR DESCRIPTION
The `apt-get` command is failing to run, and I'm not entirely sure it's necessary. I'd copied it over from the Winit CircleCI build script, so it may not be necessary here.