### PR TITLE
Packaging linked shared libraries together

### DIFF
--- a/cargo-apk/src/ops/build/compile.rs
+++ b/cargo-apk/src/ops/build/compile.rs
@@ -441,7 +441,7 @@ fn libs_search_paths_from_args(args: &[std::ffi::OsString]) -> Vec<PathBuf> {
     args.iter().filter_map(|arg| {
         if is_search_path {
             is_search_path = false;
-            arg.to_str().and_then(|arg| if arg.starts_with("native=") {
+            arg.to_str().and_then(|arg| if arg.starts_with("native=") || arg.starts_with("dependency=") {
                 Some(arg.split("=").last().unwrap().into())
             } else {
                 None


### PR DESCRIPTION
Brief explanation:

1. Getting list of needed shared libs using readelf
2. Filtering out platform libs such as _libandroid.so_, _liblog.so_ and etc.
3. Collecting libs search paths from rustc args
4. Finding needed libs in collected paths to add to _apk_

- [X] Seek libs search paths in rustc args, i.e. "-L" arg with succeeding "native=<path>" or "dependency=<path>"
- [X] Get list of platform libraries by reading directory of version dependent libraries in NDK.
- [X] Execute `readelf -d` for main shared library and seek for needed shared libs in the output by parsing lines contains "[NEEDED]" "Shared library: [<filename>]".
- [X] Exclude platform libraries from found needed libraries.
- [X] Find needed shared libs in known paths.
- [x] Add found shared libs to package.
- [X] Print warning when needed shared library not found.
- [x] Execute `readelf -d` for each found library recursively to completely resolve dependencies.

Fix for #174 